### PR TITLE
Handle dynamic ns elements and tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+.idea
+tmp/
+*.tmp
+scratch/
+build/
+*.swp
+profile.cov
+gin-bin
+
+# we don't vendor godep _workspace
+**/Godeps/_workspace/**
+
+# OSX stuff
+.DS_Store

--- a/examples/snapheka-task.json
+++ b/examples/snapheka-task.json
@@ -26,7 +26,7 @@
                     "plugin_name": "heka",                            
                     "config": {
                         "host": "SNAP_HEKA_IP",
-                        "port": "TCP_PORT"
+                        "port": TCP_PORT
                     }
                 }
             ]                                            

--- a/snapheka/snapheka_test.go
+++ b/snapheka/snapheka_test.go
@@ -5,10 +5,13 @@ package snapheka
 
 import (
 	"testing"
+	"time"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/ctypes"
+
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -53,6 +56,62 @@ func TestHekaPlugin(t *testing.T) {
 			})
 			Convey("So testConfig processing should return errors", func() {
 				So(errs.HasErrors(), ShouldBeTrue)
+			})
+		})
+	})
+
+	Convey("Create SnapHekaClient", t, func() {
+		Convey("The SnapHekaClient should not be nil", func() {
+			client, _ := NewSnapHekaClient("tcp://localhost:5600")
+			So(client, ShouldNotBeNil)
+		})
+		Convey("Testing createHekaMessage", func() {
+			var dynElt, staElt core.NamespaceElement
+			tags := map[string]string{"tag_key": "tag_val"}
+			// namespace is foo.<bar>.<name>.baz
+			namespace := core.NewNamespace("foo")
+			dynElt = core.NamespaceElement{
+				Name:        "bar",
+				Description: "",
+				Value:       "bar_val"}
+			namespace = append(namespace, dynElt)
+			dynElt = core.NamespaceElement{
+				Name:        "name",
+				Description: "",
+				Value:       "name_val"}
+			namespace = append(namespace, dynElt)
+			staElt = core.NamespaceElement{
+				Name:        "",
+				Description: "",
+				Value:       "baz"}
+			namespace = append(namespace, staElt)
+			metric := *plugin.NewMetricType(namespace, time.Now(), tags, "some unit", 3.141)
+			message, _ := createHekaMessage("some payload", metric, 1234, "host0")
+			Convey("The Heka message should not be nil", func() {
+				So(message, ShouldNotBeNil)
+			})
+			Convey("The Heka message should be as expected", func() {
+				So(message.GetHostname(), ShouldEqual, "host0")
+				So(message.GetLogger(), ShouldEqual, "snap.heka.logger")
+				So(message.GetPayload(), ShouldEqual, "some payload")
+				So(message.GetPid(), ShouldEqual, 1234)
+				So(message.GetSeverity(), ShouldEqual, 6)
+				So(message.GetType(), ShouldEqual, "snap.heka")
+				fields := message.GetFields()
+				So(fields, ShouldNotBeNil)
+				So(fields[0].GetName(), ShouldEqual, "bar")
+				So(fields[0].GetValue(), ShouldEqual, "bar_val")
+				So(fields[1].GetName(), ShouldEqual, "name")
+				So(fields[1].GetValue(), ShouldEqual, "name_val")
+				So(fields[2].GetName(), ShouldEqual, "tag_key")
+				So(fields[2].GetValue(), ShouldEqual, "tag_val")
+				So(fields[3].GetName(), ShouldEqual, "dimensions")
+				So(fields[3].GetValueString(), ShouldResemble, []string{"bar", "name", "tag_key"})
+				So(fields[4].GetName(), ShouldEqual, "name")
+				So(fields[4].GetValue(), ShouldEqual, "foo.baz")
+				So(fields[5].GetName(), ShouldEqual, "value")
+				So(fields[5].GetValue(), ShouldEqual, 3.141)
+				So(fields[6].GetName(), ShouldEqual, "timestamp")
 			})
 		})
 	})


### PR DESCRIPTION
This PR implements the changes proposed in #10. The dynamic namespace elements and  tags of a metric are now converted into fields in the corresponding Heka message. Unit tests have been added.

Please review.

Fixes #10