### PR TITLE
Update Godeps.json

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,12 +1,15 @@
 {
 	"ImportPath": "github.com/intelsdi-x/snap-plugin-publisher-heka",
-	"GoVersion": "go1.5",
+	"GoVersion": "go1.6",
+	"GodepVersion": "v74",
 	"Deps": [
 		{
-			"ImportPath": "github.com/intelsdi-x/snap"
+			"ImportPath": "github.com/intelsdi-x/snap",
+			"Rev": "d29748b02c59ace82f0b93c4b200c43683a5b5d1"
 		},
 		{
-			"ImportPath": "github.com/mozilla-services/heka"
+			"ImportPath": "github.com/mozilla-services/heka",
+			"Rev": "e8799385d16915a80b69061d05542da6342e58e4"
 		}
 	]
 }


### PR DESCRIPTION
Without this change to `Godeps.json` the following build procedure does not work:

```shell
$ cd /tmp
$ git clone https://github.com/mozilla-services/heka
$ cd heka
$ source build.sh  # this sets the env (GOPATH in particular) and build Heka
$ echo $GOPATH
/tmp/heka/build/heka
$ go get -d github.com/intelsdi-x/snap-plugin-publisher-heka
$ cd heka/src/github.com/intelsdi-x/snap
$ make deps all
$ cd ../snap-plugin-publisher-heka/
$ make deps
bash -c "godep restore"
# cd /tmp/heka/build/heka/src/github.com/mozilla-services/heka; git pull --ff-only
You are not currently on a branch. Please specify which
branch you want to merge with. See git-pull(1) for details.

    git pull <remote> <branch>

# cd /tmp/heka/build/heka/src/github.com/mozilla-services/heka; git checkout 
error: pathspec '' did not match any file(s) known to git.
godep: error restoring dep (github.com/mozilla-services/heka): exit status 1
godep: Error restoring some deps. Aborting check.
make: *** [deps] Erreur 1
```

The issue is related to `Rev` being empty in `Godeps.json` for Snap and Heka. This PR fixes the issue by using specific revisions in `Godeps.json`.

(When this is merged I'll go head and create a new PR that updates the build procedure in the README.md. That PR will fix the build issue reported in https://github.com/intelsdi-x/snap-plugin-publisher-heka/issues/4.)