### PR TITLE
Implement configuration mappings

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -204,6 +204,11 @@
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "c1cd2254a6dd314c9d73c338c12688c9325d85c6"
+		},
+		{
+			"ImportPath": "github.com/ghodss/yaml",
+			"Rev": "c3eb24aeea63668ebdac08d2e252f20df8b6b1ae"
 		}
+
 	]
 }

--- a/examples/mappings.json
+++ b/examples/mappings.json
@@ -1,0 +1,13 @@
+{
+    "severity": 6,
+    "type": "metric",
+    "logger": "test.logger",
+    "namespace": {
+        "intel.mock" : "stacklight.test",
+        "dummynamespace" : "propernamespace"
+    },
+    "metrics": {
+        "baz" : "sl-baz",
+        "dummymetric" : "propermetric"
+    }
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,7 +26,7 @@
 # 6. test coverage (http://blog.golang.org/cover)
 
 # Capture what test we should run
-TEST_TYPE="${TEST:-$1}"
+TEST_TYPE="${TEST_TYPE:-$1}"
 
 
 [[ "$TEST_TYPE" =~ ^(unit|integration)$ ]] || echo "invalid/missing TEST_TYPE (value must be 'unit' or 'integration' received:${TEST_TYPE}"

--- a/snapheka/snapheka.go
+++ b/snapheka/snapheka.go
@@ -43,7 +43,15 @@ const (
 
 // Meta returns a plugin meta data
 func Meta() *plugin.PluginMeta {
-	return plugin.NewPluginMeta(pluginName, version, pluginType, []string{plugin.SnapGOBContentType}, []string{plugin.SnapGOBContentType})
+	return plugin.NewPluginMeta(
+		pluginName,
+		version,
+		pluginType,
+		[]string{plugin.SnapGOBContentType},
+		[]string{plugin.SnapGOBContentType},
+		plugin.RoutingStrategy(plugin.StickyRouting),
+		plugin.ConcurrencyCount(1),
+	)
 }
 
 //NewHekaPublisher returns an instance of the Heka publisher

--- a/snapheka/snapheka_test.go
+++ b/snapheka/snapheka_test.go
@@ -18,7 +18,7 @@ import (
 func TestHekaPlugin(t *testing.T) {
 	Convey("Meta should return metadata for the plugin", t, func() {
 		meta := Meta()
-		So(meta.Name, ShouldResemble, name)
+		So(meta.Name, ShouldResemble, pluginName)
 		So(meta.Version, ShouldResemble, version)
 		So(meta.Type, ShouldResemble, plugin.PublisherPluginType)
 	})
@@ -42,7 +42,7 @@ func TestHekaPlugin(t *testing.T) {
 			testConfig := make(map[string]ctypes.ConfigValue)
 			testConfig["host"] = ctypes.ConfigValueStr{Value: "localhost"}
 			testConfig["port"] = ctypes.ConfigValueInt{Value: 6565}
-			cfg, errs := configPolicy.Get([]string{""}).Process(testConfig)
+			cfg, errs := configPolicy.Get([]string{vendor, pluginName}).Process(testConfig)
 			Convey("So config policy should process testConfig and return a config", func() {
 				So(cfg, ShouldNotBeNil)
 			})
@@ -50,7 +50,7 @@ func TestHekaPlugin(t *testing.T) {
 				So(errs.HasErrors(), ShouldBeFalse)
 			})
 			testConfig["port"] = ctypes.ConfigValueStr{Value: "6565"}
-			cfg, errs = configPolicy.Get([]string{""}).Process(testConfig)
+			cfg, errs = configPolicy.Get([]string{vendor, pluginName}).Process(testConfig)
 			Convey("So config policy should not return a config after processing invalid testConfig", func() {
 				So(cfg, ShouldBeNil)
 			})
@@ -62,7 +62,7 @@ func TestHekaPlugin(t *testing.T) {
 
 	Convey("Create SnapHekaClient", t, func() {
 		Convey("The SnapHekaClient should not be nil", func() {
-			client, _ := NewSnapHekaClient("tcp://localhost:5600")
+			client, _ := NewSnapHekaClient("tcp://localhost:5600", "")
 			So(client, ShouldNotBeNil)
 		})
 		Convey("Testing createHekaMessage", func() {


### PR DESCRIPTION
This PR allows some more configurable options for the Heka publishing mechanism (see JSON mappings example file)

Heka message severity, type and logger configurable
Example mappings JSON file
Uniformization of plugin configuration
Fix test.sh script for proper usage
Fix tests according to changes